### PR TITLE
Add local compose deployment configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,12 @@
+{
+    admin off
+    auto_https disable_redirects
+}
+
+http:// {
+    reverse_proxy frontend:80 {
+
+    }
+    reverse_proxy /api/* backend:3000 {
+    }
+}

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -1,88 +1,19 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   user: postgres
   password: postgres
 
 development:
   <<: *default
-  database: dej_chochle_development
+  adapter: sqlite3
+  database: db/local.sqlite3
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: backend
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: dej_chochle_test
-
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
-  database: dej_chochle_production
-  username: <%= ENV["USERNAME_PASSWORD"] %>
-  password: <%= ENV["DATABASE_PASSWORD"] %>
+  adapter: <%= ENV['DB_ADAPTER'] %>
+  database: <%= ENV['DB_NAME'] %>
+  host: <%= ENV['DB_HOST'] %>
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASS'] %>

--- a/stack-local.yaml
+++ b/stack-local.yaml
@@ -1,0 +1,55 @@
+version: '3.8'
+
+services:
+  frontend:
+    build: frontend/
+    image: ghcr.io/warehog/dej-chochle/pd-frontend:develop
+
+  backend:
+    build: backend/
+    image: ghcr.io/warehog/dej-chochle/pd-backend:develop
+    ports:
+      - 3000:3000
+    environment:
+      RAILS_ENV: production
+      DB_ADAPTER: postgresql
+      DB_HOST: db
+      DB_NAME: db_name
+      DB_USER: db_user
+      DB_PASS: db_pass
+    depends_on:
+      - migrate
+
+  migrate:
+    build: backend/
+    image: ghcr.io/warehog/dej-chochle/pd-backend:develop
+    command: ["rails", "db:migrate",]
+    environment:
+      RAILS_ENV: production
+      DB_ADAPTER: postgresql
+      DB_HOST: db
+      DB_NAME: db_name
+      DB_USER: db_user
+      DB_PASS: db_pass
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15
+    environment:
+      DB_ADAPTER: postgresql
+      POSTGRES_DB: db_name
+      POSTGRES_USER: db_user
+      POSTGRES_PASSWORD: db_pass
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  
+  proxy:
+    image: caddy
+    ports:
+      - 6776:80
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+
+volumes:
+  db_data:


### PR DESCRIPTION
Add docker compose stack definition for local deployments.

This stack will recursively build frontend and backend containers along with database and reverse proxy setup.

```bash
docker compose -f compose.local.yaml up --build
```